### PR TITLE
Fix empty array unmarshal bug and add comprehensive test suite

### DIFF
--- a/src/gencode/codes/json_parse.c
+++ b/src/gencode/codes/json_parse.c
@@ -1057,6 +1057,17 @@ static int json_unmarshal_array_internal(sstr_t content, struct json_pos* pos,
         return JSON_GEN_ERROR_PARSE;
     }
 
+    // Check for empty array immediately after '['
+    // We need to peek ahead to see if the next token is ']'
+    struct json_pos peek_pos = *pos;  // Save current position
+    tk = json_next_token(content, &peek_pos, txt);
+    if (tk == JSON_TOKEN_RIGHT_BRACKET) {
+        // Empty array case - update position and return
+        *pos = peek_pos;
+        return JSON_GEN_SUCCESS;
+    }
+    // If not empty, continue with normal parsing using original position
+
     while (1) {
         void* ptr = malloc(field->type_size);
         if (ptr == NULL) {

--- a/test/Makefile
+++ b/test/Makefile
@@ -7,8 +7,9 @@ $(shell mkdir -p $(TARGET_DIR)/test)
 
 TEST_DIR=$(TARGET_DIR)/test
 
-all: $(TEST_DIR)/unit_test $(TEST_DIR)/enhanced_test
+all: $(TEST_DIR)/unit_test $(TEST_DIR)/enhanced_test $(TEST_DIR)/empty_array_test
 
+# Generate test structures
 json.gen.c: test.json-gen-c
 	$(TARGET_DIR)/json-gen-c -in test.json-gen-c -out .
 $(TEST_DIR)/sstr.c.o: json.gen.c
@@ -22,6 +23,8 @@ $(TEST_DIR)/struct_test.cc.o: struct_test.cc
 	$(CXX) $(CXXFLAGS) -I. -c $< -o $@
 $(TEST_DIR)/enhanced_test.cc.o: enhanced_test.cc
 	$(CXX) $(CXXFLAGS) -I. -c $< -o $@
+$(TEST_DIR)/empty_array_bugfix_test.cc.o: empty_array_bugfix_test.cc
+	$(CXX) $(CXXFLAGS) -I. -c $< -o $@
 
 common_objs = $(TEST_DIR)/sstr.c.o $(TEST_DIR)/json.gen.c.o
 
@@ -29,11 +32,16 @@ test_objs = $(TEST_DIR)/simple_test.cc.o $(TEST_DIR)/struct_test.cc.o
 
 enhanced_test_objs = $(TEST_DIR)/enhanced_test.cc.o
 
+empty_array_test_objs = $(TEST_DIR)/empty_array_bugfix_test.cc.o
+
 $(TEST_DIR)/unit_test: $(common_objs) $(test_objs)
 	$(CXX) $(CXXFLAGS) $(LDFLAGS) $^ -o $@ -lgtest -lgtest_main -lpthread
 
 $(TEST_DIR)/enhanced_test: $(enhanced_test_objs)
 	$(CXX) $(CXXFLAGS) $(LDFLAGS) $^ -o $@ -lgtest -lgtest_main -lpthread -L$(ROOT_DIR)/target -lutils
+
+$(TEST_DIR)/empty_array_test: $(common_objs) $(empty_array_test_objs)
+	$(CXX) $(CXXFLAGS) $(LDFLAGS) $^ -o $@ -lgtest -lgtest_main -lpthread
 
 clean:
 	rm -rf json.gen* sstr*

--- a/test/empty_array_bugfix_test.cc
+++ b/test/empty_array_bugfix_test.cc
@@ -1,0 +1,199 @@
+#include <gtest/gtest.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "json.gen.h"
+#include "sstr.h"
+
+// Test fixture for empty array bug fix
+class EmptyArrayBugFixTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        // This will be called before each test
+    }
+
+    void TearDown() override {
+        // This will be called after each test
+    }
+};
+
+// Test that empty arrays of structs are correctly handled
+TEST_F(EmptyArrayBugFixTest, EmptyStructArrayUnmarshal) {
+    const char* empty_json = R"({
+"house":{
+"number":"288",
+"street":"1st ave."
+},
+"people":[
+]
+})";
+
+    struct Data data;
+    Data_init(&data);
+    
+    sstr_t json_str = sstr(empty_json);
+    int result = json_unmarshal_Data(json_str, &data);
+    
+    ASSERT_GE(result, 0) << "Failed to parse empty array JSON";
+    EXPECT_EQ(data.people_len, 0) << "Empty array should have length 0";
+    EXPECT_EQ(data.people, nullptr) << "Empty array should have null pointer";
+    
+    // Verify house data was parsed correctly
+    EXPECT_STREQ(sstr_cstr(data.house.number), "288");
+    EXPECT_STREQ(sstr_cstr(data.house.street), "1st ave.");
+    
+    Data_clear(&data);
+    sstr_free(json_str);
+}
+
+// Test that non-empty arrays still work correctly
+TEST_F(EmptyArrayBugFixTest, NonEmptyStructArrayUnmarshal) {
+    const char* non_empty_json = R"({
+"house":{
+"number":"288",
+"street":"1st ave."
+},
+"people":[
+{
+"name":"dogleft",
+"age":"8"
+}
+]
+})";
+
+    struct Data data;
+    Data_init(&data);
+    
+    sstr_t json_str = sstr(non_empty_json);
+    int result = json_unmarshal_Data(json_str, &data);
+    
+    ASSERT_GE(result, 0) << "Failed to parse non-empty array JSON";
+    EXPECT_EQ(data.people_len, 1) << "Non-empty array should have length 1";
+    ASSERT_NE(data.people, nullptr) << "Non-empty array should not have null pointer";
+    
+    // Verify person data
+    EXPECT_STREQ(sstr_cstr(data.people[0].name), "dogleft");
+    EXPECT_STREQ(sstr_cstr(data.people[0].age), "8");
+    
+    // Verify house data
+    EXPECT_STREQ(sstr_cstr(data.house.number), "288");
+    EXPECT_STREQ(sstr_cstr(data.house.street), "1st ave.");
+    
+    Data_clear(&data);
+    sstr_free(json_str);
+}
+
+// Test round-trip: marshal -> unmarshal -> marshal for empty arrays
+TEST_F(EmptyArrayBugFixTest, EmptyArrayRoundTrip) {
+    // Create data with empty array
+    struct Data original_data;
+    Data_init(&original_data);
+    
+    original_data.house.number = sstr("288");
+    original_data.house.street = sstr("1st ave.");
+    original_data.people_len = 0;
+    original_data.people = nullptr;
+    
+    // Marshal to JSON
+    sstr_t json_out = sstr_new();
+    json_marshal_indent_Data(&original_data, 4, 0, json_out);
+    
+    // Unmarshal back
+    struct Data result_data;
+    Data_init(&result_data);
+    int result = json_unmarshal_Data(json_out, &result_data);
+    
+    ASSERT_GE(result, 0) << "Failed to unmarshal JSON";
+    EXPECT_EQ(result_data.people_len, 0) << "Round-trip should preserve empty array";
+    EXPECT_EQ(result_data.people, nullptr) << "Round-trip should preserve null pointer";
+    
+    // Marshal again to verify consistency
+    sstr_t json_out2 = sstr_new();
+    json_marshal_indent_Data(&result_data, 4, 0, json_out2);
+    
+    // The JSON should be consistent
+    EXPECT_STREQ(sstr_cstr(json_out), sstr_cstr(json_out2)) << "Round-trip should produce identical JSON";
+    
+    // Clean up
+    Data_clear(&original_data);
+    Data_clear(&result_data);
+    sstr_free(json_out);
+    sstr_free(json_out2);
+}
+
+// Test that multiple empty arrays work correctly
+TEST_F(EmptyArrayBugFixTest, MultipleEmptyArrays) {
+    const char* multi_empty_json = R"({
+"house":{
+"number":"288",
+"street":"1st ave."
+},
+"people":[
+]
+})";
+
+    // Test multiple consecutive unmarshals
+    for (int i = 0; i < 3; i++) {
+        struct Data data;
+        Data_init(&data);
+        
+        sstr_t json_str = sstr(multi_empty_json);
+        int result = json_unmarshal_Data(json_str, &data);
+        
+        ASSERT_GE(result, 0) << "Failed to parse JSON on iteration " << i;
+        EXPECT_EQ(data.people_len, 0) << "Empty array should have length 0 on iteration " << i;
+        
+        Data_clear(&data);
+        sstr_free(json_str);
+    }
+}
+
+// Test edge case: array with only whitespace
+TEST_F(EmptyArrayBugFixTest, EmptyArrayWithWhitespace) {
+    const char* whitespace_json = R"({
+"house":{
+"number":"288",
+"street":"1st ave."
+},
+"people":[   
+  
+  
+]
+})";
+
+    struct Data data;
+    Data_init(&data);
+    
+    sstr_t json_str = sstr(whitespace_json);
+    int result = json_unmarshal_Data(json_str, &data);
+    
+    ASSERT_GE(result, 0) << "Failed to parse JSON with whitespace in empty array";
+    EXPECT_EQ(data.people_len, 0) << "Empty array with whitespace should have length 0";
+    
+    Data_clear(&data);
+    sstr_free(json_str);
+}
+
+// Test that the original bug scenario fails without the fix
+TEST_F(EmptyArrayBugFixTest, VerifyBugWasFixed) {
+    const char* empty_json = R"({"house":{"number":"288","street":"1st ave."},"people":[]})";
+    
+    struct Data data;
+    Data_init(&data);
+    
+    sstr_t json_str = sstr(empty_json);
+    int result = json_unmarshal_Data(json_str, &data);
+    
+    ASSERT_GE(result, 0) << "Failed to parse empty array JSON";
+    
+    // The bug would have created 1 element with empty strings
+    // With the fix, we should have 0 elements
+    EXPECT_EQ(data.people_len, 0) << "BUG FIXED: Empty array should not create spurious elements";
+    
+    // Verify no memory was allocated for the array
+    EXPECT_EQ(data.people, nullptr) << "BUG FIXED: Empty array should not allocate memory";
+    
+    Data_clear(&data);
+    sstr_free(json_str);
+}

--- a/test/test.json-gen-c
+++ b/test/test.json-gen-c
@@ -8,3 +8,19 @@ struct TestStruct {
 	   bool bool_val;
 	   sstr_t sstr_val;
 }
+
+// Empty array bug fix test structures
+struct House {
+    sstr_t number;
+    sstr_t street;
+}
+
+struct Person {
+    sstr_t name;
+    sstr_t age;
+}
+
+struct Data {
+    House house;
+    Person people[];
+}


### PR DESCRIPTION
This commit fixes a critical bug where empty struct arrays (e.g., "people": []) were incorrectly unmarshaled as arrays containing one element with empty/default values instead of maintaining an empty array.

Core Bug Fix:
- Added empty array detection in json_unmarshal_array_internal function
- Added peek-ahead logic to check for ']' immediately after '['
- Empty arrays now correctly unmarshal to arrays with length 0

Test Infrastructure:
- Added comprehensive Google Test suite (empty_array_bugfix_test.cc)
- Added test structures for Data, House, and Person to test.json-gen-c
- Updated test Makefile to build new empty_array_test executable
- All 26 tests pass: 13 unit + 7 enhanced + 6 empty array bug fix tests

Testing Coverage:
- Empty arrays remain empty during round-trip marshal/unmarshal
- Non-empty arrays continue to work correctly
- Multiple consecutive empty array operations
- Empty arrays with whitespace handling
- User's original reported case verification
- No regression in existing functionality

Files Modified:
- src/gencode/codes/json_parse.c: Core bug fix in unmarshal function
- test/empty_array_bugfix_test.cc: New comprehensive test suite
- test/test.json-gen-c: Combined test structure definitions
- test/Makefile: Updated build configuration

Resolves the issue where {"people": []} incorrectly became {"people": [{"name":"", "age":""}]}
Now correctly preserves empty arrays as {"people": []}