### PR TITLE
gcc 14 and cppcheck were complaining about warnings and errors.

### DIFF
--- a/src/gencode/codes/json_parse.c
+++ b/src/gencode/codes/json_parse.c
@@ -203,7 +203,6 @@ static int utf16_literal_to_utf8(sstr_t content, struct json_pos* pos,
     }
     i++;
     unsigned int first_code = parse_hex4((const unsigned char*)&data[i + 1]);
-    unsigned int second_code = 0;
     unsigned int codepoint = 0;
     i += 4;
     pos->col += 5;
@@ -217,6 +216,8 @@ static int utf16_literal_to_utf8(sstr_t content, struct json_pos* pos,
     }
     // UTF16 surrogate pair
     if ((first_code >= 0xD800) && (first_code <= 0xDBFF)) {
+        unsigned int second_code;
+
         if (i + 6 >= len) {
             sstr_clear(txt);
             sstr_append_cstr(txt, "UTF16 surrogate pair expected, but EOF");
@@ -239,7 +240,6 @@ static int utf16_literal_to_utf8(sstr_t content, struct json_pos* pos,
         /* calculate the unicode codepoint from the surrogate pair */
         codepoint =
             0x10000 + (((first_code & 0x3FF) << 10) | (second_code & 0x3FF));
-        i += 6;
         pos->col += 6;
         pos->offset += 6;
     } else {
@@ -303,7 +303,7 @@ static int utf16_literal_to_utf8(sstr_t content, struct json_pos* pos,
 static int json_parse_string_token(sstr_t content, struct json_pos* pos,
                                    sstr_t txt) {
     long len = sstr_length(content);
-    long i = pos->offset;
+    long i;
     char* data = sstr_cstr(content);
     
     // Validate input parameters
@@ -311,6 +311,8 @@ static int json_parse_string_token(sstr_t content, struct json_pos* pos,
         return JSON_ERROR;
     }
     
+    i = pos->offset;
+
     // Validate bounds before accessing data[i]
     if (i >= len) {
         sstr_clear(txt);

--- a/src/gencode/gencode.c
+++ b/src/gencode/gencode.c
@@ -640,9 +640,9 @@ static void gen_code_offset_map(struct hash_map* struct_map, sstr_t source,
                      "    int offset;\n"
                      "    int type_size;\n"
                      "    int field_type;\n"
-                     "    char* field_type_name;\n"
-                     "    char* field_name;\n"
-                     "    char* struct_name;\n"
+                     "    char* const field_type_name;\n"
+                     "    char* const field_name;\n"
+                     "    char* const struct_name;\n"
                      "    int is_array;\n"
                      "};\n\n");
     sstr_printf_append(

--- a/src/gencode/gencode.h
+++ b/src/gencode/gencode.h
@@ -27,7 +27,7 @@ extern "C" {
  * @param header the output header code.
  * @return int 0 if success, -1 if failed.
  */
-int gencode_source(struct hash_map* struct_map, sstr_t source, sstr_t header);
+extern int gencode_source(struct hash_map* struct_map, sstr_t source, sstr_t header);
 
 #ifdef __cplusplus
 }

--- a/src/utils/error_codes.h
+++ b/src/utils/error_codes.h
@@ -28,6 +28,6 @@ typedef enum {
  * @param error_code The error code
  * @return Human-readable error message
  */
-const char* json_gen_error_string(json_gen_error_t error_code);
+extern const char* json_gen_error_string(json_gen_error_t error_code);
 
 #endif /* ERROR_CODES_H */

--- a/src/utils/hash_map.h
+++ b/src/utils/hash_map.h
@@ -50,7 +50,7 @@ struct hash_map {
  * @retval NULL malloc failed.
  * @retval !NULL the new entry.
  */
-struct hash_map_entry *hash_map_entry_new(void *key, void *value);
+extern struct hash_map_entry *hash_map_entry_new(void *key, void *value);
 
 /**
  * @brief free a hash_map_entry. the key and value will be freed by
@@ -60,7 +60,7 @@ struct hash_map_entry *hash_map_entry_new(void *key, void *value);
  * map->value_free_func.
  * @param entry the entry to be freed.
  */
-void hash_map_entry_free(struct hash_map *map, struct hash_map_entry *entry);
+extern void hash_map_entry_free(struct hash_map *map, struct hash_map_entry *entry);
 
 /**
  * @brief create a new hash_map.
@@ -72,7 +72,7 @@ void hash_map_entry_free(struct hash_map *map, struct hash_map_entry *entry);
  * @param value_free_func the value free function.
  * @return struct hash_map* the new hash_map.
  */
-struct hash_map *hash_map_new(int bucket_count,
+extern struct hash_map *hash_map_new(int bucket_count,
                               unsigned int (*hash_func)(void *),
                               int (*key_cmp_func)(void *, void *),
                               void (*key_free_func)(void *),
@@ -83,7 +83,7 @@ struct hash_map *hash_map_new(int bucket_count,
  *
  * @param map the hash_map to be freed.
  */
-void hash_map_free(struct hash_map *map);
+extern void hash_map_free(struct hash_map *map);
 
 /**
  * @brief insert a new entry into hash_map.
@@ -94,7 +94,7 @@ void hash_map_free(struct hash_map *map);
  * @return int HASH_MAP_OK if success, HASH_MAP_DUPLICATE_KEY will ignore the
  *        entry, HASH_MAP_ERROR if malloc failed.
  */
-int hash_map_insert(struct hash_map *map, void *key, void *value);
+extern int hash_map_insert(struct hash_map *map, void *key, void *value);
 
 /**
  * @brief find a entry in hash_map.
@@ -104,7 +104,7 @@ int hash_map_insert(struct hash_map *map, void *key, void *value);
  * @param value the value of the entry if found.
  * @return int HASH_MAP_OK if found, HASH_MAP_ERROR if not found.
  */
-int hash_map_find(struct hash_map *map, void *key, void **value);
+extern int hash_map_find(struct hash_map *map, void *key, void **value);
 
 /**
  * @brief remove a entry from hash_map.
@@ -114,7 +114,7 @@ int hash_map_find(struct hash_map *map, void *key, void **value);
  * @return int HASH_MAP_OK if found, HASH_MAP_ERROR if not found.
  * @note the entry will be free.
  */
-int hash_map_delete(struct hash_map *map, void *key);
+extern int hash_map_delete(struct hash_map *map, void *key);
 
 /**
  * @brief for each key-value pair in hash_map, call fn(key, value).
@@ -123,7 +123,7 @@ int hash_map_delete(struct hash_map *map, void *key);
  * @param fn the function to be called.
  * @param ptr user data.
  */
-void hash_map_for_each(struct hash_map *map,
+extern void hash_map_for_each(struct hash_map *map,
                        void (*fn)(void *key, void *value, void *ptr),
                        void *ptr);
 
@@ -134,11 +134,11 @@ void hash_map_for_each(struct hash_map *map,
  * @param n the length of key buffer.
  * @return unsigned int the hash value.
  */
-unsigned int hash(const char *data, size_t n);
+extern unsigned int hash(const char *data, size_t n);
 
-unsigned int sstr_key_hash(void *key);
-int sstr_key_cmp(void *a, void *b);
-void sstr_key_free(void *key);
+extern unsigned int sstr_key_hash(void *key);
+extern int sstr_key_cmp(void *a, void *b);
+extern void sstr_key_free(void *key);
 
 #ifdef __cplusplus
 }

--- a/src/utils/io.h
+++ b/src/utils/io.h
@@ -12,8 +12,8 @@
 extern "C" {
 #endif
 
-int read_file(const char* filename, sstr_t content);
-int write_file(const char* filename, sstr_t content);
+extern int read_file(const char* filename, sstr_t content);
+extern int write_file(const char* filename, sstr_t content);
 
 #ifdef __cplusplus
 }

--- a/src/utils/json_context.h
+++ b/src/utils/json_context.h
@@ -38,13 +38,13 @@ struct json_context {
  * @brief Create a new JSON parsing context
  * @return Pointer to new context, or NULL on failure
  */
-struct json_context* json_context_new(void);
+extern struct json_context* json_context_new(void);
 
 /**
  * @brief Free a JSON parsing context
  * @param ctx Context to free
  */
-void json_context_free(struct json_context* ctx);
+extern void json_context_free(struct json_context* ctx);
 
 /**
  * @brief Initialize context with field offset data
@@ -55,7 +55,7 @@ void json_context_free(struct json_context* ctx);
  * @param hash_size Size of hash table
  * @return 0 on success, negative on error
  */
-int json_context_init(struct json_context* ctx,
+extern int json_context_init(struct json_context* ctx,
                      struct json_field_offset_item* field_items,
                      int item_count,
                      int* hash_table,
@@ -68,7 +68,7 @@ int json_context_init(struct json_context* ctx,
  * @param field_name Field name
  * @return Pointer to field offset item, or NULL if not found
  */
-struct json_field_offset_item* json_context_find_field(
+extern struct json_field_offset_item* json_context_find_field(
     struct json_context* ctx,
     const char* struct_name,
     const char* field_name);

--- a/src/utils/sstr.c
+++ b/src/utils/sstr.c
@@ -26,8 +26,8 @@
                                             : (SSTR(s)->un.ref_str.data)))
 
 static void char_to_hex(unsigned char c, unsigned char* buf, int cap) {
-    static unsigned char hex[] = "0123456789abcdef";
-    static unsigned char HEX[] = "0123456789ABCDEF";
+    static const unsigned char hex[] = "0123456789abcdef";
+    static const unsigned char HEX[] = "0123456789ABCDEF";
 
     if (cap) {
         buf[0] = HEX[((c >> 4) & 0x0f)];
@@ -324,7 +324,7 @@ sstr_t sstr_vslprintf_append(sstr_t buf, const char* fmt, va_list args) {
                         sstr_append_of(buf, p, 4);
                     } else if (hex == 0) {
                         sstr_append(buf, S);
-                    } else if (hex) {
+                    } else {
                         p = (unsigned char*)STR_PTR(S);
                         slen = sstr_length(S);
                         for (i = 0; i < slen; ++i) {
@@ -541,14 +541,15 @@ static unsigned char* sstr_sprintf_num(unsigned char* buf, unsigned char* last,
                                        unsigned width) {
     unsigned char *p, temp[SSTR_INT64_LEN + 1];
     size_t len;
-    uint32_t ui32;
-    static unsigned char hex[] = "0123456789abcdef";
-    static unsigned char HEX[] = "0123456789ABCDEF";
+    static const unsigned char hex[] = "0123456789abcdef";
+    static const unsigned char HEX[] = "0123456789ABCDEF";
 
     p = temp + SSTR_INT64_LEN;
 
     if (hexadecimal == 0) {
         if (ui64 <= (uint64_t)SSTR_MAX_UINT32_VALUE) {
+            uint32_t ui32;
+
             ui32 = (uint32_t)ui64;
 
             do {

--- a/src/utils/sstr.h
+++ b/src/utils/sstr.h
@@ -77,14 +77,14 @@ typedef void* sstr_t;
  *
  * @return sstr_t
  */
-sstr_t sstr_new();
+extern sstr_t sstr_new(void);
 
 /**
  * @brief delete a sstr_t.
  *
  * @param s sstr_t instance to delete.
  */
-void sstr_free(sstr_t s);
+extern void sstr_free(sstr_t s);
 
 /**
  * @brief Create a sstr_t from \a data with \a length bytes.
@@ -95,7 +95,7 @@ void sstr_free(sstr_t s);
  * @param length length of \a data.
  * @return sstr_t containing data copied from \a data.
  */
-sstr_t sstr_of(const void* data, size_t length);
+extern sstr_t sstr_of(const void* data, size_t length);
 
 /**
  * @brief Create a sstr_t from data with length bytes. The data is not
@@ -108,7 +108,7 @@ sstr_t sstr_of(const void* data, size_t length);
  * a reference, not a copy.
  * @note You cannot append a sstr_ref() result.
  */
-sstr_t sstr_ref(const void* data, size_t length);
+extern sstr_t sstr_ref(const void* data, size_t length);
 
 /**
  * @brief Create a sstr_t from C-style (NULL-terminated) string \a str.
@@ -118,7 +118,7 @@ sstr_t sstr_ref(const void* data, size_t length);
  * @param cstr C-style string to copy to the result sstr_t.
  * @return sstr_t containing \a data copied from cstr.
  */
-sstr_t sstr(const char* cstr);
+extern sstr_t sstr(const char* cstr);
 
 /**
  * @brief Return C-style string representation of \a s.
@@ -132,7 +132,7 @@ sstr_t sstr(const char* cstr);
  * @return char* C-style string representation of \a s.
  * @note The returned string is reused by \a s, do not free it yourself.
  */
-char* sstr_cstr(sstr_t s);
+extern char* sstr_cstr(sstr_t s);
 
 /**
  * @brief Return the length of \a s, in terms of bytes.
@@ -165,7 +165,7 @@ char* sstr_cstr(sstr_t s);
  * compared string is longer.
  * @note This function is case sensitive.
  */
-int sstr_compare(sstr_t a, sstr_t b);
+extern int sstr_compare(sstr_t a, sstr_t b);
 
 /**
  * @brief compare sstr_t \a a and \a c-style string b
@@ -173,7 +173,7 @@ int sstr_compare(sstr_t a, sstr_t b);
  *
  * @return int
  */
-int sstr_compare_c(sstr_t a, const char* b);
+extern int sstr_compare_c(sstr_t a, const char* b);
 
 /**
  * @brief Extends the sstr_t by appending additional '\0' characters at the end
@@ -182,7 +182,7 @@ int sstr_compare_c(sstr_t a, const char* b);
  * @param s destination sstr_t.
  * @param length length of '\0' to append.
  */
-void sstr_append_zero(sstr_t s, size_t length);
+extern void sstr_append_zero(sstr_t s, size_t length);
 
 /**
  * @brief Extends the sstr_t by appending additional characters in \a data with
@@ -192,7 +192,7 @@ void sstr_append_zero(sstr_t s, size_t length);
  * @param data data to append.
  * @param length length of \a data.
  */
-void sstr_append_of(sstr_t s, const void* data, size_t length);
+extern void sstr_append_of(sstr_t s, const void* data, size_t length);
 
 /**
  * @brief Extends the sstr_t by appending additional characters contained in \a
@@ -201,7 +201,7 @@ void sstr_append_of(sstr_t s, const void* data, size_t length);
  * @param dst destination sstr_t.
  * @param src source sstr_t.
  */
-void sstr_append(sstr_t dst, sstr_t src);
+extern void sstr_append(sstr_t dst, sstr_t src);
 
 /**
  * @brief Extends the sstr_t by appending additional characters contained in \a
@@ -210,7 +210,7 @@ void sstr_append(sstr_t dst, sstr_t src);
  * @param dst destination sstr_t.
  * @param src source C-style string.
  */
-void sstr_append_cstr(sstr_t dst, const char* src);
+extern void sstr_append_cstr(sstr_t dst, const char* src);
 
 /**
  * @brief Duplicate \a s and return.
@@ -218,7 +218,7 @@ void sstr_append_cstr(sstr_t dst, const char* src);
  * @param s sstr_t to duplicate.
  * @return sstr_t  duplicate of \a s.
  */
-sstr_t sstr_dup(sstr_t s);
+extern sstr_t sstr_dup(sstr_t s);
 
 /**
  * @brief Get substring of \a s starting at \a index with \a length bytes.
@@ -229,14 +229,14 @@ sstr_t sstr_dup(sstr_t s);
  * @return sstr_t substring of \a s. if \a index is out of range, return an
  * empty string.
  */
-sstr_t sstr_substr(sstr_t s, size_t index, size_t len);
+extern sstr_t sstr_substr(sstr_t s, size_t index, size_t len);
 
 /**
  * @brief clear the sstr_t. After this call, the sstr_t is empty.
  *
  * @param s sstr_t instance to clear.
  */
-void sstr_clear(sstr_t s);
+extern void sstr_clear(sstr_t s);
 
 /**
  * @brief Printf implement.
@@ -264,7 +264,7 @@ void sstr_clear(sstr_t s);
  *
  *  if %u/%x/%X, tailing d can be ignore
  */
-sstr_t sstr_vslprintf(const char* fmt, va_list args);
+extern sstr_t sstr_vslprintf(const char* fmt, va_list args);
 
 /**
  * @brief Same as sstr_vslprintf, but print to \a buf instead of create a new
@@ -275,7 +275,7 @@ sstr_t sstr_vslprintf(const char* fmt, va_list args);
  * @param args arguments.
  * @return sstr_t the result string.
  */
-sstr_t sstr_vslprintf_append(sstr_t buf, const char* fmt, va_list args);
+extern sstr_t sstr_vslprintf_append(sstr_t buf, const char* fmt, va_list args);
 
 /**
  * @brief printf implement.
@@ -284,7 +284,7 @@ sstr_t sstr_vslprintf_append(sstr_t buf, const char* fmt, va_list args);
  * @param ... arguments, like C printf()
  * @return sstr_t result string.
  */
-sstr_t sstr_printf(const char* fmt, ...);
+extern sstr_t sstr_printf(const char* fmt, ...);
 
 /**
  * @brief Same as sstr_printf(), but but print to \a buf instead of create a new
@@ -295,17 +295,17 @@ sstr_t sstr_printf(const char* fmt, ...);
  * @param ... arguments.
  * @return sstr_t the result string.
  */
-sstr_t sstr_printf_append(sstr_t buf, const char* fmt, ...);
+extern sstr_t sstr_printf_append(sstr_t buf, const char* fmt, ...);
 
 /// convert sstr <-> int,long,float,double
 
-void sstr_append_int_str(sstr_t s, int i);
-int sstr_parse_long(sstr_t s, long* v);
-int sstr_parse_int(sstr_t* s, int* v);
-void sstr_append_long_str(sstr_t s, long l);
-void sstr_append_float_str(sstr_t s, float f, int precission);
-void sstr_append_double_str(sstr_t s, double f, int precision);
-int sstr_parse_double(sstr_t s, double* v);
+extern void sstr_append_int_str(sstr_t s, int i);
+extern int sstr_parse_long(sstr_t s, long* v);
+extern int sstr_parse_int(sstr_t* s, int* v);
+extern void sstr_append_long_str(sstr_t s, long l);
+extern void sstr_append_float_str(sstr_t s, float f, int precission);
+extern void sstr_append_double_str(sstr_t s, double f, int precision);
+extern int sstr_parse_double(sstr_t s, double* v);
 
 /**
  * @brief Append if cond is true, otherwise do nothing.
@@ -315,7 +315,7 @@ int sstr_parse_double(sstr_t s, double* v);
  * @param length length of \a data.
  * @param cond condition
  */
-void sstr_append_of_if(sstr_t s, const void* data, size_t length, int cond);
+extern void sstr_append_of_if(sstr_t s, const void* data, size_t length, int cond);
 /**
  * @brief Append C style string if cond is true, otherwise do nothing.
  * @param dst destination sstr_t to append to.
@@ -326,7 +326,7 @@ void sstr_append_of_if(sstr_t s, const void* data, size_t length, int cond);
     sstr_append_of_if(dst, src, strlen(src), cond)
 
 // escape string to json string format
-int sstr_json_escape_string_append(sstr_t out, sstr_t in);
+extern int sstr_json_escape_string_append(sstr_t out, sstr_t in);
 
 /**
  * @brief append spaces at the end of the sstr_t.
@@ -334,14 +334,14 @@ int sstr_json_escape_string_append(sstr_t out, sstr_t in);
  * @param s the sstr_t to append spaces to.
  * @param indent numbers of spaces to append.
  */
-void sstr_append_indent(sstr_t s, size_t indent);
+extern void sstr_append_indent(sstr_t s, size_t indent);
 
 /**
  * @brief return version string.
  *
  * @return const char* static version string.
  */
-const char* sstr_version();
+extern const char* sstr_version(void);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
- Missing 'extern'
- Missing 'void' for function parameter
- Test for null before reading
- Reduced scope of variable
- Value increased but not used
- EOL consistent
- 'const' missing for char pointer.